### PR TITLE
Update Nuget packages and implement new EdDsaSignatureProvider.Verify function

### DIFF
--- a/samples/ScottBrady.IdentityModel.Samples.AspNetCore/ScottBrady.IdentityModel.Samples.AspNetCore.csproj
+++ b/samples/ScottBrady.IdentityModel.Samples.AspNetCore/ScottBrady.IdentityModel.Samples.AspNetCore.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ScottBrady.IdentityModel.AspNetCore/ScottBrady.IdentityModel.AspNetCore.csproj
+++ b/src/ScottBrady.IdentityModel.AspNetCore/ScottBrady.IdentityModel.AspNetCore.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3" PrivateAssets="all" />
+        <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="all" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 

--- a/src/ScottBrady.IdentityModel.Tokens.Branca/ScottBrady.IdentityModel.Tokens.Branca.csproj
+++ b/src/ScottBrady.IdentityModel.Tokens.Branca/ScottBrady.IdentityModel.Tokens.Branca.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="NaCl.Core" Version="2.0.4" />
-        <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3" PrivateAssets="all" />
+        <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ScottBrady.IdentityModel/ScottBrady.IdentityModel.csproj
+++ b/src/ScottBrady.IdentityModel/ScottBrady.IdentityModel.csproj
@@ -17,10 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.10.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.10.0" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3" PrivateAssets="all" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.23.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.23.1" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ScottBrady.IdentityModel/Tokens/EdDsa.cs
+++ b/src/ScottBrady.IdentityModel/Tokens/EdDsa.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Parameters;
@@ -71,6 +72,17 @@ public class EdDsa
         return signer.GenerateSignature();
     }
 
+    public bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength)
+    {
+        
+        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (signature == null) throw new ArgumentNullException(nameof(signature));
+        if (inputLength <= 0) throw new ArgumentException($"{nameof(inputLength)} must be greater than 0");
+        if (signatureLength <= 0) throw new ArgumentException($"{nameof(signatureLength)} must be greater than 0");
+        
+        return Verify(input.Skip(inputOffset).Take(inputLength).ToArray(), signature.Skip(signatureOffset).Take(signatureLength).ToArray());
+    }
+    
     public bool Verify(byte[] input, byte[] signature)
     {
         if (input == null) throw new ArgumentNullException(nameof(input));

--- a/src/ScottBrady.IdentityModel/Tokens/EdDsaSignatureProvider.cs
+++ b/src/ScottBrady.IdentityModel/Tokens/EdDsaSignatureProvider.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Microsoft.IdentityModel.Tokens;
 
 namespace ScottBrady.IdentityModel.Tokens
@@ -13,8 +15,9 @@ namespace ScottBrady.IdentityModel.Tokens
         }
 
         protected override void Dispose(bool disposing) { }
-        
         public override byte[] Sign(byte[] input) => edDsaKey.EdDsa.Sign(input);
         public override bool Verify(byte[] input, byte[] signature) => edDsaKey.EdDsa.Verify(input, signature);
+        public override bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength) 
+            => edDsaKey.EdDsa.Verify(input, inputOffset, inputLength, signature, signatureOffset, signatureLength);
     }
 }

--- a/test/ScottBrady.IdentityModel.Tests/ScottBrady.IdentityModel.Tests.csproj
+++ b/test/ScottBrady.IdentityModel.Tests/ScottBrady.IdentityModel.Tests.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.21.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
 

--- a/test/ScottBrady.IdentityModel.Tests/Tokens/EdDSA/EdDsaSignatureProviderTests.cs
+++ b/test/ScottBrady.IdentityModel.Tests/Tokens/EdDSA/EdDsaSignatureProviderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using FluentAssertions;
 using Microsoft.IdentityModel.Tokens;
@@ -62,5 +63,31 @@ namespace ScottBrady.IdentityModel.Tests.Tokens.EdDSA
 
             isValidSignature.Should().BeTrue();
         }
+        
+        [Fact]
+        public void VerifyWithOffsets_WhenJwtSignedWithEd25519Curve_ExpectTrue()
+        {
+            const string plaintext =
+                "eyJraWQiOiIxMjMiLCJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.eyJhdWQiOiJ5b3UiLCJzdWIiOiJib2IiLCJpc3MiOiJtZSIsImV4cCI6MTU5MDg0MTg4N30";
+            const string signature =
+                "OyBxBr344Ny-0vRCeEMLSnuEO1IecybvJBivrjum4d-dgN5WLnEAGAO43MlZeRGn1F3fRXO_xlYot68PtDuiAA";
+            
+            const string publicKey = "60mR98SQlHUSeLeIu7TeJBTLRG10qlcDLU4AJjQdqMQ";
+            var edDsaSecurityKey = new EdDsaSecurityKey(EdDsa.Create(
+                new EdDsaParameters(ExtendedSecurityAlgorithms.Curves.Ed25519) {X = Base64UrlEncoder.DecodeBytes(publicKey)}));
+
+            var signatureProvider = new EdDsaSignatureProvider(edDsaSecurityKey, ExtendedSecurityAlgorithms.EdDsa);
+
+            var inputBytes = Encoding.UTF8.GetBytes(plaintext);
+            var signatureBytes = Base64UrlEncoder.DecodeBytes(signature);
+            
+            var isValidSignature = signatureProvider.Verify(
+                inputBytes,
+                0, inputBytes.Length,
+                signatureBytes, 0,signatureBytes.Length);
+    
+            isValidSignature.Should().BeTrue();
+        }
+        
     }
 }

--- a/test/ScottBrady.IdentityModel.Tests/Tokens/EdDSA/EdDsaTests.cs
+++ b/test/ScottBrady.IdentityModel.Tests/Tokens/EdDSA/EdDsaTests.cs
@@ -63,6 +63,26 @@ public class EdDsaTests
     public void Verify_WhenSignatureNull_ExpectArgumentNullException()
         => Assert.Throws<ArgumentNullException>(() => EdDsa.Create(ExtendedSecurityAlgorithms.Curves.Ed25519).Verify(new byte[32], null));
     
+    [Fact]
+    public void VerifyWithOffsets_WhenSignatureNull_ExpectArgumentNullException()
+        => Assert.Throws<ArgumentNullException>(() => 
+            EdDsa.Create(ExtendedSecurityAlgorithms.Curves.Ed25519).Verify(new byte[32],0,0, null,0,32));    
+ 
+    [Fact]
+    public void VerifyWithOffsets_WhenInputNull_ExpectArgumentNullException()
+        => Assert.Throws<ArgumentNullException>(() => 
+            EdDsa.Create(ExtendedSecurityAlgorithms.Curves.Ed25519).Verify(null,0,0, new byte[32],0,32));  
+    
+    [Fact]
+    public void VerifyWithOffsets_WhenInputLengthZero_ExpectArgumentException()
+        => Assert.Throws<ArgumentException>(() => 
+            EdDsa.Create(ExtendedSecurityAlgorithms.Curves.Ed25519).Verify(new byte[32],0,0, new byte[32],0,32));
+    
+    [Fact]
+    public void VerifyWithOffsets_WhenSignatureLengthZero_ExpectArgumentException()
+        => Assert.Throws<ArgumentException>(() => 
+            EdDsa.Create(ExtendedSecurityAlgorithms.Curves.Ed25519).Verify(new byte[32],0,32, new byte[32],0,0));
+    
     private static AsymmetricCipherKeyPair GenerateEd25519KeyPair()
     {
         var keyPairGenerator = new Ed25519KeyPairGenerator();


### PR DESCRIPTION
This is a new version of #9. 

---------------------------------------------------

This PR does a few things: 

Updated all Nuget packages to their latest versions. 

Implements a new ``` Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength) ``` override in ``EdDsaSignatureProvider`` as well as a corresponding ``Verify`` function in ``EdDsa``. 

The new ``Verify`` function was added into ``Microsoft.IdentityModel.Tokens.SignatureProvider`` in the following [PR](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/1934) - and was causing validation failures when validating signatures on tokens signed with ``EdDSA``.

I also implemented some tests to confirm that new functionality is working as expected. 

As a side note I noticed that 6 of the ``PasetoTestVectors.ValidateToken_ExpectCorrectResult`` tests are failing when I run them locally - these were failing before I upgraded any nuget packages - and continue to fail after the update - so I didn't make any changes to them. 

![image](https://user-images.githubusercontent.com/60940949/190027526-b843e8c0-c6b4-486d-b5ba-2ae7aa8c1ab8.png)
